### PR TITLE
Update introduction-to-classes.ipynb - added self parameter to the bark method in Dog class

### DIFF
--- a/notebooks/lesson2/introduction-to-classes.ipynb
+++ b/notebooks/lesson2/introduction-to-classes.ipynb
@@ -61,7 +61,7 @@
     "class Dog:\n",
     "    is_animal = True\n",
     "\n",
-    "    def bark():\n",
+    "    def bark(self):\n",
     "        print(\"woof!\")\n",
     "\n",
     "dog = Dog()"


### PR DESCRIPTION
**self** parameter is missing at the **bark** method in the **Dog** class. This gives an unexpected error even before the **self** parameter is introduced in the **Cat** class.